### PR TITLE
update configs, ignore files in packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           name: Mutation Tests
           command: |
             mv ~/reports/junit.xml reports/coverage-xml/junit.xml
-            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml
+            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml --skip-initial-tests
       - store_artifacts:
           path: reports/infection.html
           destination: infection.html

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+/.circleci              export-ignore
+/.github                export-ignore
+/tests                  export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/build.xml              export-ignore
+/infection.json.dist    export-ignore
+/phpcs.xml.dist         export-ignore
+/phpmd.xml.dist         export-ignore
+/phpstan.neon.dist      export-ignore
+/phpunit.xml.dist       export-ignore
+/psalm.xml.dist         export-ignore

--- a/build.xml
+++ b/build.xml
@@ -141,6 +141,7 @@
             <arg value="--min-msi=100" />
             <arg value="--min-covered-msi=100" />
             <arg value="--coverage=reports" />
+            <arg value="--skip-initial-tests" />
         </exec>
     </target>
 </project>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,6 +3,7 @@
          name="Code Standards"
          xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
     <file>src/</file>
+    <file>tests/</file>
 
     <config name="ignore_warnings_on_exit" value="1"/>
 

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="Benchmarks ruleset"
+<ruleset name="Base Template ruleset"
          xmlns="http://pmd.sf.net/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
                      http://pmd.sf.net/ruleset_xml_schema.xsd"
          xsi:noNamespaceSchemaLocation="
                      http://pmd.sf.net/ruleset_xml_schema.xsd">
-    <description>Custom rules for Bitwise Operations</description>
+    <description>Custom rules for Base Template</description>
 
     <rule ref="rulesets/codesize.xml">
         <exclude name="CyclomaticComplexity"/>


### PR DESCRIPTION
* infection now skips initial tests and relies on the code coverage report
* unnecessary files are ignored for package creation
* phpcs checks the tests directory
* phpmd is more generic