### PR TITLE
add yamllint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,7 @@ jobs:
       - enable_extensions
       - run:
           name: Unit Tests
-          command: php -d pcov.enabled=1 vendor/bin/phpunit \
-            --coverage-html ~/reports/code-coverage \
-            --coverage-xml reports/coverage-xml \
-            --log-junit ~/reports/junit.xml
+          command: php -d pcov.enabled=1 vendor/bin/phpunit --coverage-html ~/reports/code-coverage --coverage-xml reports/coverage-xml --log-junit ~/reports/junit.xml
       - store_artifacts:
           path: ~/reports/code-coverage
           destination: code-coverage
@@ -136,8 +133,7 @@ jobs:
           name: Mutation Tests
           command: |
             mv ~/reports/junit.xml reports/coverage-xml/junit.xml
-            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 \
-              --coverage=reports/coverage-xml --skip-initial-tests
+            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml --skip-initial-tests
       - store_artifacts:
           path: reports/infection.html
           destination: infection.html
@@ -153,8 +149,7 @@ jobs:
             sudo apt install xsltproc
       - run:
           name: Psalm
-          command: vendor/bin/psalm --output-format=xml | \
-            xsltproc vendor/roave/psalm-html-output/psalm-html-output.xsl - > ~/reports/psalm.html
+          command: vendor/bin/psalm --output-format=xml | xsltproc vendor/roave/psalm-html-output/psalm-html-output.xsl - > ~/reports/psalm.html
       - store_artifacts:
           path: ~/reports/psalm.html
           destination: psalm.html
@@ -168,8 +163,8 @@ jobs:
       - run:
           name: YAML Lint
           command: |
-            sudo apt install yamllint
-            yammllint .
+            sudo apt-get install yamllint
+            yamllint .
       - run:
           name: Code Standards
           command: vendor/bin/phpcs -n

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,4 +208,4 @@ workflows:
       - psalm:
           requires:
             - job-init
-      - yaml:
+      - yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ executors:
     docker:
       - image: cimg/php:8.1
     resource_class: medium
+  python-3:
+    docker:
+      - image: python:latest
 
 orbs:
   php: circleci/php@1.1.0
@@ -161,11 +164,6 @@ jobs:
           name: Lint
           command: vendor/bin/parallel-lint --exclude .git --exclude vendor --colors .
       - run:
-          name: YAML Lint
-          command: |
-            sudo apt-get install yamllint
-            yamllint .
-      - run:
           name: Code Standards
           command: vendor/bin/phpcs -n
       - run:
@@ -186,6 +184,16 @@ jobs:
       - store_artifacts:
           path: reports/psalm-security.sarif
           destination: psalm-security.sarif
+  yaml:
+    executor: python-3
+    steps:
+      - checkout_code
+      - run:
+          name: Install YAML Lint
+          command: pip install yamllint
+      - run:
+          name: YAML Lint
+          command: yamllint .
 
 workflows:
   build:
@@ -200,3 +208,4 @@ workflows:
       - psalm:
           requires:
             - job-init
+      - yaml:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ executors:
   php-81:
     docker:
       - image: cimg/php:8.1
-    resource_class: medium
+    resource_class: large
   python-3:
     docker:
       - image: python:latest
-    resource_class: medium
+    resource_class: large
 
 orbs:
   php: circleci/php@1.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ executors:
   python-3:
     docker:
       - image: python:latest
+    resource_class: medium
 
 orbs:
   php: circleci/php@1.1.0
@@ -198,7 +199,10 @@ jobs:
 workflows:
   build:
     jobs:
-      - job-init
+      - yaml
+      - job-init:
+          requires:
+            - yaml
       - test:
           requires:
             - job-init
@@ -208,4 +212,3 @@ workflows:
       - psalm:
           requires:
             - job-init
-      - yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,10 @@ jobs:
       - enable_extensions
       - run:
           name: Unit Tests
-          command: php -d pcov.enabled=1 vendor/bin/phpunit --coverage-html ~/reports/code-coverage --coverage-xml reports/coverage-xml --log-junit ~/reports/junit.xml
+          command: php -d pcov.enabled=1 vendor/bin/phpunit \
+            --coverage-html ~/reports/code-coverage \
+            --coverage-xml reports/coverage-xml \
+            --log-junit ~/reports/junit.xml
       - store_artifacts:
           path: ~/reports/code-coverage
           destination: code-coverage
@@ -133,7 +136,8 @@ jobs:
           name: Mutation Tests
           command: |
             mv ~/reports/junit.xml reports/coverage-xml/junit.xml
-            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml --skip-initial-tests
+            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 \
+              --coverage=reports/coverage-xml --skip-initial-tests
       - store_artifacts:
           path: reports/infection.html
           destination: infection.html
@@ -149,7 +153,8 @@ jobs:
             sudo apt install xsltproc
       - run:
           name: Psalm
-          command: vendor/bin/psalm --output-format=xml | xsltproc vendor/roave/psalm-html-output/psalm-html-output.xsl - > ~/reports/psalm.html
+          command: vendor/bin/psalm --output-format=xml | \
+            xsltproc vendor/roave/psalm-html-output/psalm-html-output.xsl - > ~/reports/psalm.html
       - store_artifacts:
           path: ~/reports/psalm.html
           destination: psalm.html
@@ -160,6 +165,11 @@ jobs:
       - run:
           name: Lint
           command: vendor/bin/parallel-lint --exclude .git --exclude vendor --colors .
+      - run:
+          name: YAML Lint
+          command: |
+            sudo apt install yamllint
+            yammllint .
       - run:
           name: Code Standards
           command: vendor/bin/phpcs -n

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,80 @@
+yaml-files:
+  - "*.yaml"
+  - "*.yml"
+  - ".yamllint"
+
+ignore: |
+  vendor/
+  node_modules/
+
+# See https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  braces:
+    forbid: "non-empty"
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    forbid: "non-empty"
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 2
+  document-end:
+    present: false
+  document-start:
+    present: false
+  empty-lines:
+    max: 1
+    max-start: 0
+    max-end: 0
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  float-values:
+    forbid-inf: true
+    forbid-nan: true
+    forbid-scientific-notation: true
+    require-numeral-before-decimal: true
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: {}
+  line-length:
+    level: "warning"
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false
+  new-line-at-end-of-file: {}
+  new-lines:
+    type: "unix"
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  quoted-strings:
+    quote-type: "double"
+    required: false
+    extra-required: []
+    extra-allowed: []
+    allow-quoted-quotes: false
+  trailing-spaces: {}
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: true

--- a/build.xml
+++ b/build.xml
@@ -75,6 +75,23 @@
             <arg path="src" />
             <arg path="tests" />
         </exec>
+        <exec command="which yamllint" returnProperty="return.code"/>
+        <if>
+            <isfailure code="${return.code}"/>
+            <then>
+                <echo message="Install yamllint to lint yaml files"/>
+            </then>
+            <else>
+                <exec
+                        executable="yamllint"
+                        logoutput="true"
+                        passthru="true"
+                        checkreturn="true"
+                >
+                    <arg path="." />
+                </exec>
+            </else>
+        </if>
     </target>
 
     <target name="cs">


### PR DESCRIPTION
YAML Lint is now available to validate YAML files.

## Local
`vendor/bin/phing`

## CI
`yamllint .`

This does NOT fix errors, only display errors and warnings. Warnings do not fail the job.
